### PR TITLE
Added 'application/rss+xml' as an acceptable content type

### DIFF
--- a/AFOnoResponseSerializer/AFOnoResponseSerializer.m
+++ b/AFOnoResponseSerializer/AFOnoResponseSerializer.m
@@ -101,7 +101,7 @@
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"text/xml", @"application/xml", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"text/xml", @"application/xml", @"application/rss+xml", nil];
 
     return self;
 }


### PR DESCRIPTION
I stumbled across multiple RSS feeds that use "application/rss+xml" in the content type header. As it seems to be quite common, adding to the default set of acceptable content types seems appropriate.
